### PR TITLE
Replace vote proof by activation tx and adapt SmartRewards UI tab

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -234,7 +234,7 @@ bool CTransaction::IsVoteKeyRegistration() const
     return false;
 }
 
-bool CTransaction::IsVoteProof() const
+bool CTransaction::IsActivationTx() const
 {
     if (IsCoinBase()) return false;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -15,14 +15,8 @@
 static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
 // Constants for vote proof transactions
-static const CAmount REWARDS_VOTEPROOF_FEE = 0 * COIN;
-static const CAmount REWARDS_VOTEPROOF_TX_FEE = 0.002 * COIN;
-
-static const int REWARDS_VOTEPROOF_O1_SCRIPT_SIZE = 0x28;
-static const int REWARDS_VOTEPROOF_O1_DATA_SIZE = 0x26;
-
-static const int REWARDS_VOTEPROOF_O2_SCRIPT_SIZE = 0x3D;
-static const int REWARDS_VOTEPROOF_O2_DATA_SIZE = 0x3B;
+static const CAmount REWARDS_ACTIVATION_FEE = 0 * COIN;
+static const CAmount REWARDS_ACTIVATION_TX_FEE = 0.002 * COIN;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 
@@ -229,11 +223,6 @@ public:
     bool IsVoteKeyRegistrationData() const
     {
         return scriptPubKey.IsVoteKeyData() && nValue == VOTEKEY_REGISTER_FEE;
-    }
-
-    bool IsVoteProofData() const
-    {
-        return scriptPubKey.IsVoteProofData() && nValue == REWARDS_VOTEPROOF_FEE;
     }
 
     uint32_t GetLockTime() const;
@@ -475,7 +464,7 @@ public:
     bool IsZerocoinMint(const CTransaction& tx) const;
 
     bool IsVoteKeyRegistration() const;
-    bool IsVoteProof() const;
+    bool IsActivationTx() const;
 
     friend bool operator==(const CTransaction& a, const CTransaction& b)
     {

--- a/src/qt/forms/smartrewardentry.ui
+++ b/src/qt/forms/smartrewardentry.ui
@@ -19,20 +19,6 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <property name="styleSheet">
-   <string notr="true">#QSmartRewardEntry{
- 
-	background-color: rgb(247, 245, 248);
-}
-
-#eligiblePage{
-  background-color: rgb(247, 245, 248);
-}
-
-#infoPage{
-  background-color: rgb(247, 245, 248);
-}</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -205,7 +191,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Voting required. Go to the SmartVoting Tab and vote for a proposal</string>
+          <string>Activation required. Click button below to activate this address for rewards</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/qt/smartrewardentry.cpp
+++ b/src/qt/smartrewardentry.cpp
@@ -87,19 +87,14 @@ void QSmartRewardEntry::setEligible(CAmount nEligible, CAmount nEstimated)
     ui->lblEstimated->setText(strEstimated + " SMART");
 }
 
-void QSmartRewardEntry::setVoted(bool fState)
+void QSmartRewardEntry::setActivated(bool fState)
 {
-    fVoted = fState;
+    fActivated = fState;
 }
 
 void QSmartRewardEntry::setIsSmartNode(bool fState)
 {
     fIsSmartNode = fState;
-}
-
-void QSmartRewardEntry::setVoteProofConfirmations(int nConfirmations)
-{
-    nVoteProofConfirmations = nConfirmations;
 }
 
 QString QSmartRewardEntry::Address() const
@@ -114,12 +109,6 @@ QSmartRewardEntry::State QSmartRewardEntry::CurrentState()
     if( fIsSmartNode ) return IsASmartNode;
 
     if( !disqualifyingTx.IsNull() ) return OutgoingTransaction;
-
-//    if( !fVoted ) return VotingRequired;
-
-    if( nVoteProofConfirmations == -1 ) return VoteProofRequired;
-
-    if( nVoteProofConfirmations < Params().GetConsensus().nRewardsConfirmationsRequired ) return VoteProofConfirmationsRequired;
 
     if( nEligible ) return IsEligible;
 

--- a/src/qt/smartrewardentry.h
+++ b/src/qt/smartrewardentry.h
@@ -25,9 +25,6 @@ public:
         LowBalance,
         IsASmartNode,
         OutgoingTransaction,
-        VotingRequired,
-        VoteProofRequired,
-        VoteProofConfirmationsRequired,
         IsEligible
     };
 
@@ -37,16 +34,14 @@ public:
     void setInfoText(const QString& strText, const QColor& color);
     void setEligible(CAmount nEligible, CAmount nEstimated);
     void setIsSmartNode(bool fState);
-    void setVoted(bool fState);
-    void setVoteProofConfirmations(int nConfirmations);
+    void setActivated(bool fState);
 
     QString Address() const;
     CAmount Balance() const { return nBalance; }
     CAmount BalanceAtStart() const { return nBalanceAtStart; }
     CAmount Eligible() const { return nEligible; }
     bool IsSmartNode() const { return fIsSmartNode; }
-    bool Voted() const { return fVoted; }
-    int VoteProofConfirmations() const { return nVoteProofConfirmations; }
+    bool Activated() const { return fActivated; }
     State CurrentState();
 
     std::string ToString();
@@ -64,8 +59,7 @@ private:
     CAmount nBalance;
     CAmount nEligible;
     bool fIsSmartNode;
-    bool fVoted;
-    int nVoteProofConfirmations;
+    bool fActivated;
     uint256 disqualifyingTx;
 
 private Q_SLOTS:

--- a/src/qt/smartvoting.cpp
+++ b/src/qt/smartvoting.cpp
@@ -51,8 +51,7 @@ SmartVotingPage::SmartVotingPage(const PlatformStyle *platformStyle, QWidget *pa
     QWidget(parent),
     ui(new Ui::SmartVotingPage),
     platformStyle(platformStyle),
-    walletModel(0),
-    nVoteProofRequired(0)
+    walletModel(0)
 {
     ui->setupUi(this);
 
@@ -197,32 +196,12 @@ void SmartVotingPage::castVotes(){
 
     CastVotesDialog dialog(platformStyle, votingManager, walletModel);
 
-    connect( &dialog, SIGNAL(votedForAddress(QString&, int, bool)), this, SLOT(voteDone(QString&, int, bool)));
     dialog.setVoting(mapVoteProposals);
-
-    nVoteProofRequired = 0;
 
     dialog.exec();
 
-    if( nVoteProofRequired ){
-
-        // Display message box
-        QMessageBox::StandardButton retval = QMessageBox::question(this, tr("VoteProof required"),
-            tr("Do you want to send a VoteProof for %1 address%2 to enable SmartRewards?\n\nThis can also be done later in the SmartRewards Tab.").arg(nVoteProofRequired).arg( nVoteProofRequired > 1 ? "es" : ""),
-            QMessageBox::Yes | QMessageBox::No,
-            QMessageBox::Yes);
-
-        if(retval == QMessageBox::Yes){
-            SpecialTransactionDialog dlg(VOTE_PROOF_TRANSACTIONS, platformStyle);
-            dlg.setModel(walletModel);
-            dlg.exec();
-        }
-
-    }
-
     refreshProposals(true);
     uiInterface.NotifySmartRewardUpdate();
-
 }
 
 void SmartVotingPage::updateRefreshLock()
@@ -269,40 +248,3 @@ void SmartVotingPage::balanceChanged(const CAmount &balance, const CAmount &unco
     updateUI();
 }
 
-void SmartVotingPage::voteDone(QString &address, int nProposalId, bool successful)
-{
-    if( successful ){
-
-        LOCK(pwalletMain->cs_wallet);
-
-        CKeyID keyId;
-        std::string strProposal = strprintf("%d", nProposalId);
-        uint256 nProposalHash = Hash(strProposal.begin(), strProposal.end());
-        CSmartAddress id(address.toStdString());
-
-        if(id.GetKeyID(keyId)){
-
-            LOCK(cs_rewardscache);
-
-            int nCurrentRound = prewards->GetCurrentRound()->number;
-
-            if( !pwalletMain->mapVoted[keyId].count(nCurrentRound) ){
-
-                pwalletMain->mapVoted[keyId].insert(std::make_pair(nCurrentRound, nProposalHash));
-                pwalletMain->UpdateVotedMap(keyId);
-            }
-
-            CSmartRewardEntry * entry;
-
-            if( nCurrentRound >= Params().GetConsensus().nRewardsFirst_1_3_Round &&
-                pwalletMain->mapVoteProofs[keyId].find(nCurrentRound) == pwalletMain->mapVoteProofs[keyId].end() &&
-                prewards->GetRewardEntry(CSmartAddress(id.ToString(false)), entry, false) ){
-
-                if( entry->balanceEligible && !entry->fSmartnodePaymentTx ){
-                    ++nVoteProofRequired;
-                }
-            }
-        }
-    }
-
-}

--- a/src/qt/smartvoting.h
+++ b/src/qt/smartvoting.h
@@ -60,8 +60,6 @@ private:
     std::vector<SmartProposalWidget*> vecProposalWidgets;
     std::map<SmartProposal, SmartHiveVoting::Type> mapVoteProposals;
 
-    int nVoteProofRequired;
-    
 public Q_SLOTS:
     void updateUI();
     void updateProposalUI();
@@ -74,6 +72,5 @@ public Q_SLOTS:
     void scrollChanged(int value);
     void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                         const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
-    void voteDone(QString &address, int nProposalId, bool successful);
 };
 #endif // BITCOIN_QT_SMARTVOTING_H

--- a/src/qt/specialtransactiondialog.cpp
+++ b/src/qt/specialtransactiondialog.cpp
@@ -65,13 +65,13 @@ SpecialTransactionDialog::SpecialTransactionDialog(const SpecialTransactionType 
         ui->labelFeeDesc->setText(strRegistrationFeeDescription);
         ui->descriptionLabel->setText(strRegistrationDescription);
         break;
-    case VOTE_PROOF_TRANSACTIONS: // TBD
-        nRequiredFee = REWARDS_VOTEPROOF_FEE;
-        nRequiredNetworkFee = REWARDS_VOTEPROOF_TX_FEE;
-        this->setWindowTitle(strVoteProofTitle);
+    case ACTIVATION_TRANSACTIONS:
+        nRequiredFee = REWARDS_ACTIVATION_FEE;
+        nRequiredNetworkFee = REWARDS_ACTIVATION_TX_FEE;
+        this->setWindowTitle(strActivationTxTitle);
         ui->labelFeeDesc->hide();
         ui->labelFeeAmount->hide();
-        ui->descriptionLabel->setText(strVoteProofDescription);
+        ui->descriptionLabel->setText(strActivationTxDescription);
         break;
     default:
         nRequiredFee = -1;
@@ -135,19 +135,6 @@ void SpecialTransactionDialog::setModel(WalletModel *model)
     }
 }
 
-QString SpecialTransactionDialog::GetTypeString()
-{
-
-    switch(type){
-    case REGISTRATION_TRANSACTIONS:
-        return "registration transactions";
-    case VOTE_PROOF_TRANSACTIONS:
-        return "vote proof transactions";
-    }
-
-    return "Unknown";
-}
-
 // ok button
 void SpecialTransactionDialog::buttonBoxClicked(QAbstractButton* button)
 {
@@ -161,7 +148,18 @@ void SpecialTransactionDialog::buttonBoxClicked(QAbstractButton* button)
             LogPrintf("  %s, out: %s\n", it.first.toStdString(), it.second.ToString());
         }
 
-        QString strType = GetTypeString();
+        QString strType;
+        switch(type){
+        case REGISTRATION_TRANSACTIONS:
+          strType = nCount > 1 ? "registration transactions" : "registration transaction";
+          break;
+        case ACTIVATION_TRANSACTIONS:
+          strType = nCount > 1 ? "activation transactions" : "activation transaction";
+          break;
+        default:
+          strType = "Unknown";
+          break;
+        }
 
         QString questionString = QString("Sending %1 %2, %3 each including fee")
                 .arg(nCount)
@@ -232,8 +230,8 @@ void SpecialTransactionDialog::buttonBoxClicked(QAbstractButton* button)
                                   "They are not derived from the wallet's seed so you are not able to recover them "
                                   "with any earlier backup of your wallet."));
                 break;
-            case VOTE_PROOF_TRANSACTIONS:
-                strResult.append(tr("It requires %1 block confirmation for the VoteProof transactions before the address will become eligible in the SmartRewards tab.").arg(Params().GetConsensus().nRewardsConfirmationsRequired));
+            case ACTIVATION_TRANSACTIONS:
+                strResult.append(tr("It requires %1 block confirmation for the activation transactions before the address will become eligible in the SmartRewards tab.").arg(Params().GetConsensus().nRewardsConfirmationsRequired));
                 break;
             }
 
@@ -380,7 +378,7 @@ void SpecialTransactionDialog::SendTransactions(std::vector<QString> &vecErrors)
         case REGISTRATION_TRANSACTIONS:
             fSuccess = SendRegistration(it.first, it.second, strError);
             break;
-        case VOTE_PROOF_TRANSACTIONS:{
+        case ACTIVATION_TRANSACTIONS:{
 
             int nCurrentRound;
 
@@ -389,7 +387,7 @@ void SpecialTransactionDialog::SendTransactions(std::vector<QString> &vecErrors)
                 nCurrentRound = prewards->GetCurrentRound()->number;
             }
 
-            fSuccess = SendVoteProof(it.first, it.second, nCurrentRound, strError);
+            fSuccess = SendActivationTransaction(it.first, it.second, nCurrentRound, strError);
         }break;
         }
 
@@ -584,7 +582,7 @@ bool SpecialTransactionDialog::SendRegistration(const QString &address, const CO
     return true;
 }
 
-bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutPoint &out, int nCurrentRound, QString &strError)
+bool SpecialTransactionDialog::SendActivationTransaction(const QString &address, const COutPoint &out, int nCurrentRound, QString &strError)
 {
     // **
     // Check if the unspent output belongs to <address> or not
@@ -594,12 +592,12 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
     uint256 blockHash;
 
     if( !GetTransaction(out.hash, spendTx, Params().GetConsensus(), blockHash, true) )
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("TX-Hash %s doesn't belong to a transaction",out.hash.ToString()),
               strError);
 
     if( static_cast<uint32_t>(spendTx.vout.size()) - 1 < out.n )
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("TX-Index %d out of range for TX %s",out.n, out.hash.ToString()),
               strError);
 
@@ -612,21 +610,21 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
     CSmartAddress voteAddress(address.toStdString());
 
     if ( !voteAddress.IsValid() )
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Failed to validate address for TX %s, index %s", out.hash.ToString(), out.n),
               strError);
 
     CKeyID voteAddressKeyID;
 
     if (!voteAddress.GetKeyID(voteAddressKeyID))
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Address does't refer to a key for TX %s, index %s", out.hash.ToString(), out.n),
               strError);
 
     CTxDestination addressSolved;
 
     if (!ExtractDestination(utxo.scriptPubKey, addressSolved)) {
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Failed to extract address for output with TX %s, index %s",
                         out.hash.ToString(), out.n),
               strError);
@@ -636,36 +634,11 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
 
     // Force option 1 - verify the vote address with the input of the register tx
     if(  !CSmartAddress(addressSolved).GetKeyID(keyIdSolved) || keyIdSolved != voteAddressKeyID ){
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Failed to force vote proof option one for address %s with TX %s, index %s",
                         voteAddress.ToString(), out.hash.ToString(), out.n),
               strError);
     }
-
-    // **
-    // ** Prepare the VoteProof data
-    // **
-
-/*    if( pwalletMain->mapVoted[voteAddressKeyID].find(nCurrentRound) == pwalletMain->mapVoted[voteAddressKeyID].end() ){
-        return Error("GenerateVoteProof",
-              strprintf("Address %s did not yet vote during the SmartRewards round %d",
-                        voteAddress.ToString(), nCurrentRound),
-              strError);
-    }
-*/
-/*    std::vector<unsigned char> vecData = {
-        OP_RETURN_VOTE_PROOF_FLAG,
-        0x01 // Proof option 1
-    };
-
-    CDataStream proofData(SER_NETWORK,0);
-
-    proofData << nCurrentRound;
-    proofData << pwalletMain->mapVoted[voteAddressKeyID][nCurrentRound];
-
-    vecData.insert(vecData.end(), proofData.begin(), proofData.end());
-*/
-    CScript proofScript = CScript();  // << OP_RETURN << vecData;
 
     // **
     // Create the transaction
@@ -680,6 +653,20 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
     coinControl.Select(output);
     coinControl.destChange = change;
 
+    // Write script to self address
+    CScript proofScript = GetScriptForDestination(addressSolved);
+
+
+    // Figure out how much the output contains
+    map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.find(out.hash);
+    if (it == pwalletMain->mapWallet.end())
+        return Error("GenerateActivation",
+              "Failed to find output transaction in wallet",
+              strError);
+
+    const CWalletTx &tx = it->second;
+    CAmount nOutputAmount = tx.vout[out.n].nValue;
+
     // Create and send the transaction
     CReserveKey reservekey(pwalletMain);
     CWalletTx proofTx;
@@ -688,12 +675,12 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
     vector<CRecipient> vecSend;
     int nChangePosRet = -1;
 
-    CRecipient recipient = {proofScript, REWARDS_VOTEPROOF_FEE, false};
+    CRecipient recipient = {proofScript, nOutputAmount, true};
     vecSend.push_back(recipient);
 
     if (!pwalletMain->CreateTransaction(vecSend, proofTx, reservekey, nFeeRequired, nChangePosRet,
                                          err, &coinControl))
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Failed to generate transaction: %s for TX %s, index %d", err, out.hash.ToString(), out.n),
               strError);
 
@@ -702,19 +689,13 @@ bool SpecialTransactionDialog::SendVoteProof(const QString &address, const COutP
 
     CValidationState state;
     if (!(CheckTransaction(proofTx, state, proofTx.GetHash(), false) || !state.IsValid()))
-        return Error("GenerateVoteProof",
-              strprintf("VoteProof transaction invalid for TX %s, index %d: %s",
+        return Error("GenerateActivation",
+              strprintf("Activation transaction invalid for TX %s, index %d: %s",
                         out.hash.ToString(), out.n, state.GetRejectReason()),
               strError);
 
-    {
-        LOCK(pwalletMain->cs_wallet);
-        pwalletMain->mapVoteProofs[voteAddressKeyID].insert(std::make_pair(nCurrentRound, proofTx.GetHash()));
-        pwalletMain->UpdateVoteProofs(voteAddressKeyID);
-    }
-
     if( !pwalletMain->CommitTransaction(proofTx, reservekey, g_connman.get()) )
-        return Error("GenerateVoteProof",
+        return Error("GenerateActivation",
               strprintf("Failed to send the transaction TX %s", proofTx.ToString()),
               strError);
 
@@ -854,7 +835,7 @@ void SpecialTransactionDialog::updateView()
 
         }
 
-        if( type == VOTE_PROOF_TRANSACTIONS ){
+        if( type == ACTIVATION_TRANSACTIONS ){
             CKeyID keyId;
             CSmartAddress voteAddress(sWalletAddress.toStdString());
             int nCurrentRound = 0;
@@ -864,20 +845,7 @@ void SpecialTransactionDialog::updateView()
                 nCurrentRound = prewards->GetCurrentRound()->number;
             }
 
-            CSmartRewardEntry *reward = nullptr;
-
-            if( voteAddress.GetKeyID(keyId) && prewards->GetRewardEntry(CSmartAddress::Legacy(voteAddress), reward, false) ){
-
-                LOCK(pwalletMain->cs_wallet);
-
-                if( //pwalletMain->mapVoted[keyId].find(nCurrentRound) == pwalletMain->mapVoted[keyId].end() ||
-                    pwalletMain->mapVoteProofs[keyId].find(nCurrentRound) != pwalletMain->mapVoteProofs[keyId].end() ||
-                    reward->balanceEligible == 0 || !reward->disqualifyingTx.IsNull() || !reward->smartnodePaymentTx.IsNull() ){
-                    // If not yet voted, no eligible balance or already vote proven skip it.
-                    continue;
-                }
-
-            }else{
+            if( !voteAddress.GetKeyID(keyId) ){
                 continue;
             }
         }

--- a/src/qt/specialtransactiondialog.h
+++ b/src/qt/specialtransactiondialog.h
@@ -31,7 +31,7 @@ namespace Ui {
 
 enum SpecialTransactionType {
     REGISTRATION_TRANSACTIONS,
-    VOTE_PROOF_TRANSACTIONS
+    ACTIVATION_TRANSACTIONS
 };
 
 #define ASYMP_UTF8 "\xE2\x89\x88"
@@ -71,7 +71,7 @@ private:
 
     void SendTransactions(std::vector<QString> &vecErrors);
     bool SendRegistration(const QString &address, const COutPoint &out, QString &strError);
-    bool SendVoteProof(const QString &address, const COutPoint &out, int nCurrentRound, QString &strError);
+    bool SendActivationTransaction(const QString &address, const COutPoint &out, int nCurrentRound, QString &strError);
 
     enum
     {
@@ -84,7 +84,6 @@ private:
     };
     friend class CCoinControlWidgetItem;
 
-    QString GetTypeString();
 private Q_SLOTS:
     void showMenu(const QPoint &);
     void copyAddress();
@@ -103,10 +102,10 @@ static const QString strRegistrationDescription = (
 );
 static const QString strRegistrationFeeDescription = "Register fee";
 
-static const QString strVoteProofTitle = "Activate Rewards";
-static const QString strVoteProofDescription = (
+static const QString strActivationTxTitle = "Activate Rewards";
+static const QString strActivationTxDescription = (
 "Use this form to send an ActivateReward transaction to make your addresses eligible for SmartRewards. "
-"A small fee of 0.001 SMART will be taken from outputs you choose.\n\n"
+"A small fee of 0.002 SMART will be taken from outputs you choose.\n\n"
 "You can either manually select an input for each address or automatically select the smallest input for each address by clicking the checkbox below."
 );
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -67,7 +67,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("size", (int)::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
-    entry.push_back(Pair("activation", tx.IsVoteProof()));
+    entry.push_back(Pair("activation", tx.IsActivationTx()));
     UniValue vin(UniValue::VARR);
     BOOST_FOREACH(const CTxIn& txin, tx.vin) {
         UniValue in(UniValue::VOBJ);

--- a/src/rpc/smartrewards.cpp
+++ b/src/rpc/smartrewards.cpp
@@ -262,7 +262,7 @@ UniValue smartrewards(const UniValue& params, bool fHelp)
         obj.pushKV("balance", format(entry->balance));
         obj.pushKV("balance_eligible", format(entry->balanceEligible));
         obj.pushKV("is_smartnode", !entry->smartnodePaymentTx.IsNull());
-        obj.pushKV("voted", !entry->voteProof.IsNull());
+        obj.pushKV("activated", entry->fActivated);
         obj.pushKV("eligible", current->number < nFirst_1_3_Round ? entry->balanceEligible > 0 : entry->IsEligible());
 
         return obj;

--- a/src/sapi/sapi_smartrewards.cpp
+++ b/src/sapi/sapi_smartrewards.cpp
@@ -91,7 +91,7 @@ static bool CheckAddresses(HTTPRequest* req, std::vector<std::string> vecAddr, s
         obj.pushKV("balance",UniValueFromAmount(entry->balance));
         obj.pushKV("balance_eligible", UniValueFromAmount(entry->balanceEligible));
         obj.pushKV("is_smartnode", !entry->smartnodePaymentTx.IsNull());
-        obj.pushKV("voted", !entry->voteProof.IsNull());
+        obj.pushKV("activated", entry->fActivated);
         obj.pushKV("eligible", current->number < nFirst_1_3_Round ? entry->balanceEligible > 0 : entry->IsEligible());
 
         vecResults.push_back(obj);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -353,29 +353,6 @@ bool CScript::IsVoteKeyData() const {
             (*this)[4] == 0x02);
 }
 
-bool CScript::IsVoteProofData() const {
-
-    return (this->size() == REWARDS_VOTEPROOF_O1_SCRIPT_SIZE &&
-            (*this)[0] == OP_RETURN &&
-            (*this)[1] == REWARDS_VOTEPROOF_O1_DATA_SIZE &&
-            (*this)[2] == OP_RETURN_VOTE_PROOF_FLAG &&
-            (*this)[3] == 0x01);
-
-    /*
-    return  (this->size() == REWARDS_VOTEPROOF_O1_SCRIPT_SIZE &&
-            (*this)[0] == OP_RETURN &&
-            (*this)[1] == REWARDS_VOTEPROOF_O1_DATA_SIZE &&
-            (*this)[2] == OP_RETURN_VOTE_PROOF_FLAG &&
-            (*this)[3] == 0x01) ||
-
-            (this->size() == REWARDS_VOTEPROOF_O2_SCRIPT_SIZE &&
-            (*this)[0] == OP_RETURN &&
-            (*this)[1] == REWARDS_VOTEPROOF_O2_DATA_SIZE &&
-            (*this)[2] == OP_RETURN_VOTE_PROOF_FLAG &&
-            (*this)[3] == 0x02);
-    */
-}
-
 bool CScript::HasCanonicalPushes() const
 {
     const_iterator pc = begin();

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -640,11 +640,10 @@ public:
     bool IsPayToScriptHashLocked() const;
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
-    
+
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;
     bool IsVoteKeyData() const;
-    bool IsVoteProofData() const;
     // Called by IsStandardTx.
     bool HasCanonicalPushes() const;
 

--- a/src/smartrewards/rewards.cpp
+++ b/src/smartrewards/rewards.cpp
@@ -267,7 +267,7 @@ void CSmartRewards::EvaluateRound(CSmartRewardRound& nextRewardRound)
 LogPrintf("Testing1 %s\n", smartRewardEntry->second->ToString());
              smartRewardEntry->second->balanceEligible = 0;
         // If we are in a 1.3 round, eligble, we have a minbalance, calculate the weighted balance.
-        if (Is_1_3(currentRound->number) && smartRewardEntry->second->balance >= nMinBalance && smartRewardEntry->second->fVoteProven) {
+        if (Is_1_3(currentRound->number) && smartRewardEntry->second->balance >= nMinBalance && smartRewardEntry->second->fActivated) {
             smartRewardEntry->second->balanceEligible = CalculateWeightedBalance(smartRewardEntry->first, smartRewardEntry->second, currentRound->number);
         }
         // If we are in a 1.2 round, we have a minimum balance, and no disqualifying transactions or smarthive.
@@ -289,7 +289,7 @@ LogPrintf("Testing1 %s\n", smartRewardEntry->second->ToString());
                 smartRewardEntry->second->balanceEligible = CalculateWeightedBalance(smartRewardEntry->first, smartRewardEntry->second, currentRound->number);
             }
         }*/
-        if (smartRewardEntry->second->balanceEligible > 0 && ((currentRound->number == (nFirst_1_3_Round -1) && smartRewardEntry->second->fVoteProven) || currentRound->number != (nFirst_1_3_Round -1)) ) {
+        if (smartRewardEntry->second->balanceEligible > 0 && ((currentRound->number == (nFirst_1_3_Round -1) && smartRewardEntry->second->fActivated) || currentRound->number != (nFirst_1_3_Round -1)) ) {
             ++nextRewardRound.eligibleEntries;
             nextRewardRound.eligibleSmart += smartRewardEntry->second->balanceEligible;
         }
@@ -334,8 +334,8 @@ LogPrintf("Testing Reward %d\n", currentRound->percent); */
         smartRewardEntry2->second->fSmartnodePaymentTx = false;
         // Prior to first 1.3 round clear voteproven
         if (currentRound->number == (nFirst_1_3_Round - 1)) {
-            smartRewardEntry2->second->voteProof.SetNull();
-            smartRewardEntry2->second->fVoteProven = false;
+            smartRewardEntry2->second->activationTx.SetNull();
+            smartRewardEntry2->second->fActivated = false;
         }
         ++smartRewardEntry2;
     }
@@ -562,7 +562,7 @@ const CSmartRewardRoundMap* CSmartRewards::GetRewardRounds()
     return cache.GetRounds();
 }
 
-void CSmartRewards::ProcessInput(const CTransaction& tx, const CTxOut& in, CSmartAddress** voteProofCheck, CAmount& nVoteProofIn, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result)
+void CSmartRewards::ProcessInput(const CTransaction& tx, const CTxOut& in, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result)
 {
     CSmartRewardEntry* rEntry = nullptr;
     CSmartAddress id;
@@ -576,12 +576,12 @@ void CSmartRewards::ProcessInput(const CTransaction& tx, const CTxOut& in, CSmar
         LogPrint("smartrewards-tx", "CSmartRewards::ProcessInput - Spend without previous receive - %s", tx.ToString());
         return;
     }
-    if (Is_1_3(nCurrentRound) && tx.IsVoteProof()) {
+    if (Is_1_3(nCurrentRound) && tx.IsActivationTx()) {
         rEntry->balance += in.nValue;
     }
         rEntry->balance -= in.nValue;
 
-    if( Is_1_3(nCurrentRound) && !tx.IsVoteProof() && !rEntry->fDisqualifyingTx ){
+    if( Is_1_3(nCurrentRound) && !tx.IsActivationTx() && !rEntry->fDisqualifyingTx ){
 
         if( rEntry->IsEligible() ){
             result.disqualifiedEntries++;
@@ -590,8 +590,8 @@ void CSmartRewards::ProcessInput(const CTransaction& tx, const CTxOut& in, CSmar
 
         rEntry->disqualifyingTx = tx.GetHash();
         rEntry->fDisqualifyingTx = true;
-        rEntry->voteProof.SetNull();
-        rEntry->fVoteProven = false;
+        rEntry->activationTx.SetNull();
+        rEntry->fActivated = false;
 
     }else if( nCurrentRound && !Is_1_3(nCurrentRound) && !rEntry->fDisqualifyingTx ){
 
@@ -611,7 +611,7 @@ void CSmartRewards::ProcessInput(const CTransaction& tx, const CTxOut& in, CSmar
     }
 }
 
-void CSmartRewards::ProcessOutput(const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount nVoteProofIn, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result)
+void CSmartRewards::ProcessOutput(const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result)
 {
     CSmartRewardEntry* rEntry = nullptr;
     CSmartAddress id;
@@ -621,19 +621,10 @@ void CSmartRewards::ProcessOutput(const CTransaction& tx, const CTxOut& out, CSm
         return;
     } else {
         if (GetRewardEntry(id, rEntry, true)) {
-            //We only add balance if is not the vote proof transaction. Vote proof transaction is just to activate the address
-/*            if (!tx.IsVoteProof() || !Is_1_3(nCurrentRound)) {
-                if ( rEntry->IsEligible() ) {
-                     result.disqualifiedEntries++;
-                     result.disqualifiedSmart += rEntry->balanceEligible;
-                }
-                rEntry->disqualifyingTx = tx.GetHash();
-                rEntry->fDisqualifyingTx = true;
-            }
-*/            if (tx.IsVoteProof() && Is_1_3(nCurrentRound)) {
-                if (!rEntry->fVoteProven) {
-                    rEntry->voteProof = tx.GetHash();
-                    rEntry->fVoteProven = true;
+            if (tx.IsActivationTx() && Is_1_3(nCurrentRound)) {
+                if (!rEntry->fActivated) {
+                    rEntry->activationTx = tx.GetHash();
+                    rEntry->fActivated = true;
                     if ( rEntry->IsEligible() ) {
                        result.qualifiedEntries++;
                        result.qualifiedSmart += rEntry->balanceEligible;
@@ -699,7 +690,6 @@ bool CSmartRewards::ProcessTransaction(CBlockIndex* pIndex, const CTransaction& 
 
 void CSmartRewards::UndoInput(const CTransaction& tx, const CTxOut& in, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result)
 {
-//    uint32_t nFirst_1_3_Round = Params().GetConsensus().nRewardsFirst_1_3_Round;
     CSmartRewardEntry* rEntry = nullptr;
     CSmartAddress id;
 
@@ -712,16 +702,16 @@ void CSmartRewards::UndoInput(const CTransaction& tx, const CTxOut& in, uint16_t
         LogPrint("smartrewards-tx", "CSmartRewards::UndoInput - Spend without previous receive - %s", tx.ToString());
         return;
     }
-    if (Is_1_3(nCurrentRound) && tx.IsVoteProof()) {
+    if (Is_1_3(nCurrentRound) && tx.IsActivationTx()) {
         rEntry->balance -= in.nValue;
     }
     rEntry->balance += in.nValue;
 
-    if (Is_1_3(nCurrentRound) && !tx.IsVoteProof() && rEntry->disqualifyingTx == tx.GetHash()) {
+    if (Is_1_3(nCurrentRound) && !tx.IsActivationTx() && rEntry->disqualifyingTx == tx.GetHash()) {
         rEntry->disqualifyingTx.SetNull();
         rEntry->fDisqualifyingTx = false;
-        rEntry->voteProof = tx.GetHash();
-        rEntry->fVoteProven = true;
+        rEntry->activationTx = tx.GetHash();
+        rEntry->fActivated = true;
 
         if (rEntry->IsEligible()) {
             --result.disqualifiedEntries;
@@ -737,14 +727,9 @@ void CSmartRewards::UndoInput(const CTransaction& tx, const CTxOut& in, uint16_t
             result.disqualifiedSmart -= rEntry->balanceEligible;
         }
     }
-
-/*    if (rEntry->balance < 0) {
-        LogPrint("smartrewards-tx", "CSmartRewards::UndoInput - Negative amount?! - %s", rEntry->ToString());
-        rEntry->balance = 0;
-    }*/
 }
 
-void CSmartRewards::UndoOutput(const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount& nVoteProofIn, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result)
+void CSmartRewards::UndoOutput(const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result)
 {
     CSmartRewardEntry* rEntry = nullptr;
     CSmartAddress id;
@@ -754,33 +739,17 @@ void CSmartRewards::UndoOutput(const CTransaction& tx, const CTxOut& out, CSmart
         return;
     } else {
         GetRewardEntry(id, rEntry, true);
-//        if (Is_1_3(nCurrentRound) && tx.IsCoinBase()) {
-            // If it's a voteproof set voteproven and undisqualify transactions
-        if (tx.IsVoteProof() && Is_1_3(nCurrentRound)) {
-            if (!rEntry->fVoteProven) {
-                rEntry->voteProof.SetNull();
-                rEntry->fVoteProven = false;
-/*            }
-            if (rEntry->disqualifyingTx == tx.GetHash()) {
-                rEntry->disqualifyingTx.SetNull();
-                rEntry->fDisqualifyingTx = false;
- */             if (rEntry->IsEligible()) {
+        if (tx.IsActivationTx() && Is_1_3(nCurrentRound)) {
+            if (!rEntry->fActivated) {
+                rEntry->activationTx.SetNull();
+                rEntry->fActivated = false;
+                if (rEntry->IsEligible()) {
                     --result.disqualifiedEntries;
                     result.disqualifiedSmart -= rEntry->balanceEligible;
                 }
             }
         }
-/*            // If it isn't a voteproof transaction disqualify it.
-        if (rEntry->fVoteProven && !SmartHive::IsHive(rEntry->id)) {
-            rEntry->voteProof.SetNull();
-            rEntry->fVoteProven = false;
-            --result.qualifiedEntries;
-            result.qualifiedSmart -= rEntry->balanceEligible;
-            if ( tx.IsVoteProof() ){
-                rEntry->balance += nVoteProofIn - tx.GetValueOut();
-            }
-        }
-*/
+
         rEntry->balance -= out.nValue;
 
         // If we are in the 1.3 cycles check for node rewards to remove node addresses from lists
@@ -833,29 +802,11 @@ void CSmartRewards::UndoTransaction(CBlockIndex* pIndex, const CTransaction& tx,
         return;
     }
 
-    CSmartAddress* voteProofCheck = nullptr;
-    CAmount nVoteProofIn = 0;
-
-    if (Is_1_3(nCurrentRound) && tx.IsVoteProof()) {
-        const Coin& coin = coins.AccessCoin(tx.vin[0].prevout);
-        const CTxOut& rOut = coin.out;
-
-        CSmartAddress id;
-
-        if (!ExtractDestination(rOut.scriptPubKey, id)) {
-            LogPrint("smartrewards-tx", "CSmartRewards::UndoTransaction - Process VoteProof: Could't parse CSmartAddress: %s\n", rOut.ToString());
-            return;
-        }
-
-        nVoteProofIn = 0; // rOut.nValue;
-        voteProofCheck = new CSmartAddress(id);
-    }
-
     BOOST_REVERSE_FOREACH (const CTxOut& out, tx.vout) {
         if (out.scriptPubKey.IsZerocoinMint())
             continue;
 
-        UndoOutput(tx, out, voteProofCheck, nVoteProofIn, nCurrentRound, result);
+        UndoOutput(tx, out, nCurrentRound, result);
     }
 
     int nTime2 = GetTimeMicros();

--- a/src/smartrewards/rewards.h
+++ b/src/smartrewards/rewards.h
@@ -162,11 +162,11 @@ public:
     bool Update(CBlockIndex* pindexNew, const CChainParams& chainparams, const int nCurrentRound, CSmartRewardsUpdateResult& result);
     bool UpdateRound(const CSmartRewardRound& round);
 
-    void ProcessInput(const CTransaction& tx, const CTxOut& in, CSmartAddress** voteProofCheck, CAmount& nVoteProofIn, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result);
-    void ProcessOutput(const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount nVoteProofIn, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
+    void ProcessInput(const CTransaction& tx, const CTxOut& in, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result);
+    void ProcessOutput(const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
 
     void UndoInput(const CTransaction& tx, const CTxOut& in, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result);
-    void UndoOutput(const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount& nVoteProofIn, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result);
+    void UndoOutput(const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, CSmartRewardsUpdateResult& result);
 
     bool ProcessTransaction(CBlockIndex* pIndex, const CTransaction& tx, int nCurrentRound);
     void UndoTransaction(CBlockIndex* pIndex, const CTransaction& tx, CCoinsViewCache& coins, const CChainParams& chainparams, CSmartRewardsUpdateResult& result);
@@ -192,9 +192,9 @@ public:
 
     bool Is_1_3(uint16_t currentRoundNumber);
 
-    void ProcessOutputFor1_2(CSmartRewardEntry* smartRewardEntry, const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount nVoteProofIn, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
+    void ProcessOutputFor1_2(CSmartRewardEntry* smartRewardEntry, const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
 
-    void ProcessOutputFor1_3(CSmartRewardEntry* smartRewardEntry, const CTransaction& tx, const CTxOut& out, CSmartAddress* voteProofCheck, CAmount nVoteProofIn, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
+    void ProcessOutputFor1_3(CSmartRewardEntry* smartRewardEntry, const CTransaction& tx, const CTxOut& out, uint16_t nCurrentRound, int nHeight, CSmartRewardsUpdateResult& result);
 
     CAmount CalculateWeightedBalance(CSmartAddress address, CSmartRewardEntry* smartRewardEntry, uint16_t currentRoundNumber);
 

--- a/src/smartrewards/rewardsdb.cpp
+++ b/src/smartrewards/rewardsdb.cpp
@@ -371,25 +371,25 @@ void CSmartRewardEntry::SetNull()
     fDisqualifyingTx = false;
     smartnodePaymentTx.SetNull();
     fSmartnodePaymentTx = false;
-    voteProof.SetNull();
-    fVoteProven = false;
+    activationTx.SetNull();
+    fActivated = false;
 }
 
 string CSmartRewardEntry::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CSmartRewardEntry(id=%s, balance=%d, balanceEligible=%d, isSmartNode=%b, voteProven=%b)\n",
+    s << strprintf("CSmartRewardEntry(id=%s, balance=%d, balanceEligible=%d, isSmartNode=%b, activated=%b)\n",
         GetAddress(),
         balance,
         balanceEligible,
         fSmartnodePaymentTx,
-        fVoteProven);
+        fActivated);
     return s.str();
 }
 
 bool CSmartRewardEntry::IsEligible()
 {
-    return fVoteProven && !fSmartnodePaymentTx && balanceEligible > 0 && !fDisqualifyingTx;
+    return fActivated && !fSmartnodePaymentTx && balanceEligible > 0 && !fDisqualifyingTx;
 }
 
 string CSmartRewardBlock::ToString() const

--- a/src/smartrewards/rewardsdb.h
+++ b/src/smartrewards/rewardsdb.h
@@ -183,6 +183,7 @@ public:
     int GetPayeeCount() const { return nPayeeCount; }
     int GetRewardBlocks() const { return nRewardBlocks; }
     int GetLastRoundBlock() const { return nLastRoundBlock; }
+    bool Is_1_3() const { return number >= Params().GetConsensus().nRewardsFirst_1_3_Round; }
 
     std::string ToString() const;
 };
@@ -202,8 +203,8 @@ public:
         READWRITE(balanceEligible);
         READWRITE(disqualifyingTx);
         READWRITE(fDisqualifyingTx);
-        READWRITE(voteProof);
-        READWRITE(fVoteProven);
+        READWRITE(activationTx);
+        READWRITE(fActivated);
         READWRITE(smartnodePaymentTx);
         READWRITE(fSmartnodePaymentTx);
     }
@@ -214,20 +215,20 @@ public:
     CAmount balanceEligible;
     uint256 disqualifyingTx;
     bool fDisqualifyingTx;
-    uint256 voteProof;
-    bool fVoteProven;
+    uint256 activationTx;
+    bool fActivated;
     uint256 smartnodePaymentTx;
     bool fSmartnodePaymentTx;
 
     CSmartRewardEntry() : id(CSmartAddress()),
                           balance(0), balanceAtStart(0), balanceEligible(0),
                           disqualifyingTx(uint256()), fDisqualifyingTx(false),
-                          voteProof(uint256()), fVoteProven(false),
+                          activationTx(uint256()), fActivated(false),
                           smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false) {}
     CSmartRewardEntry(const CSmartAddress &address) : id(address),
                           balance(0), balanceAtStart(0), balanceEligible(0),
                           disqualifyingTx(uint256()), fDisqualifyingTx(false),
-                          voteProof(uint256()), fVoteProven(false),
+                          activationTx(uint256()), fActivated(false),
                           smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false) {}
 
     friend bool operator==(const CSmartRewardEntry& a, const CSmartRewardEntry& b)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2398,9 +2398,6 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         std::map<std::pair<uint160, int>, CAmount> vecInputs;
         std::map<std::pair<uint160, int>, CAmount> vecOutputs;
 
-        CSmartAddress *voteProofCheck = nullptr;
-        CAmount nVoteProofIn = 0;
-
         int nCurrentRewardsRound = prewards->GetCurrentRound()->number;
         bool fProcessRewards = !fIsVerifyDB && prewards->ProcessTransaction(pindex, tx, nCurrentRewardsRound);
 
@@ -2439,7 +2436,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
                 const CTxOut &prevout = coin.out;
 
                 if( fProcessRewards && !input.scriptSig.IsZerocoinSpend() ){
-                    prewards->ProcessInput(tx, prevout, &voteProofCheck, nVoteProofIn, nCurrentRewardsRound, smartRewardsResult);
+                    prewards->ProcessInput(tx, prevout, nCurrentRewardsRound, smartRewardsResult);
                 }
 
                 if (fAddressIndex || fSpentIndex || fDepositIndex)
@@ -2530,7 +2527,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
             const CTxOut &out = tx.vout[k];
 
             if( fProcessRewards && !out.scriptPubKey.IsZerocoinMint() ){
-                prewards->ProcessOutput(tx, out, voteProofCheck, nVoteProofIn, nCurrentRewardsRound, pindex->nHeight, smartRewardsResult);
+                prewards->ProcessOutput(tx, out, nCurrentRewardsRound, pindex->nHeight, smartRewardsResult);
             }
 
             if (fAddressIndex || fDepositIndex) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -461,28 +461,6 @@ bool CWallet::UpdateVotingKeyRegistration(const CKeyID &keyId) {
     return CWalletDB(strWalletFile).UpdateVotingKeyRegistration(keyId, mapVotingKeyRegistrations[keyId]);
 }
 
-bool CWallet::LoadVotedMap(const CKeyID &keyId, const std::map<int64_t, uint256> &mapVoted) {
-    AssertLockHeld(cs_wallet);
-    this->mapVoted[keyId] = mapVoted;
-    return true;
-}
-
-bool CWallet::UpdateVotedMap(const CKeyID &keyId) {
-    AssertLockHeld(cs_wallet);
-    return CWalletDB(strWalletFile).UpdateVotedMap(keyId, mapVoted[keyId]);
-}
-
-bool CWallet::LoadVoteProofs(const CKeyID &keyId, const std::map<int64_t, uint256> &mapVoteProofs) {
-    AssertLockHeld(cs_wallet);
-    this->mapVoteProofs[keyId] = mapVoteProofs;
-    return true;
-}
-
-bool CWallet::UpdateVoteProofs(const CKeyID &keyId) {
-    AssertLockHeld(cs_wallet);
-    return CWalletDB(strWalletFile).UpdateVoteProofs(keyId, mapVoteProofs[keyId]);
-}
-
 bool CWallet::LoadCryptedVotingKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret) {
     return CCryptoKeyStore::AddCryptedVotingKey(vchPubKey, vchCryptedSecret);
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -675,10 +675,6 @@ public:
     std::map<CKeyID, CVotingKeyMetadata> mapVotingKeyMetadata;
     std::map<CKeyID, uint256> mapVotingKeyRegistrations;
 
-    /* SmartRewards Vote proof */
-    std::map<CKeyID, std::map<int64_t, uint256>> mapVoted;
-    std::map<CKeyID, std::map<int64_t, uint256>> mapVoteProofs;
-
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
@@ -840,14 +836,6 @@ public:
     bool LoadVotingKeyRegistration(const CKeyID &keyId, const uint256 &txhash);
     //! Update votekeys registrations
     bool UpdateVotingKeyRegistration(const CKeyID &keyId);
-    //! Load voted rounds per address (used by LoadWallet)
-    bool LoadVotedMap(const CKeyID &keyId, const std::map<int64_t, uint256> &mapVoted);
-    //! Update voted round per address
-    bool UpdateVotedMap(const CKeyID &keyId);
-    //! Load vote proofs per address (used by LoadWallet)
-    bool LoadVoteProofs(const CKeyID &keyId, const std::map<int64_t, uint256> &mapVoteProofs);
-    //! Update vote proofs per address
-    bool UpdateVoteProofs(const CKeyID &keyId);
     //! Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedVotingKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -135,20 +135,6 @@ bool CWalletDB::UpdateVotingKeyRegistration(const CKeyID& keyId, const uint256& 
                txHash, true);
 }
 
-bool CWalletDB::UpdateVotedMap(const CKeyID& keyId, const std::map<int64_t, uint256>& mapVoted)
-{
-    nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("vmap"), keyId),
-               mapVoted, true);
-}
-
-bool CWalletDB::UpdateVoteProofs(const CKeyID& keyId, const std::map<int64_t, uint256>& mapVoteProofs)
-{
-    nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("vproofs"), keyId),
-               mapVoteProofs, true);
-}
-
 bool CWalletDB::WriteVotingKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CVotingKeyMetadata& keyMeta)
 {
     nWalletDBUpdated++;
@@ -747,26 +733,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             wss.nVKeyRegistration++;
 
             pwallet->LoadVotingKeyRegistration(keyId, txHash);
-        }
-        else if (strType == "vmap")
-        {
-            CKeyID keyId;
-            ssKey >> keyId;
-            std::map<int64_t, uint256> mapVoted;
-            ssValue >> mapVoted;
-            wss.nMapVoted++;
-
-            pwallet->LoadVotedMap(keyId, mapVoted);
-        }
-        else if (strType == "vproofs")
-        {
-            CKeyID keyId;
-            ssKey >> keyId;
-            std::map<int64_t,  uint256> mapVoteProofs;
-            ssValue >> mapVoteProofs;
-            wss.nMapVoteProofs++;
-
-            pwallet->LoadVoteProofs(keyId, mapVoteProofs);
         }
         else if (strType == "defaultkey")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -166,8 +166,6 @@ public:
     bool WriteVotingMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
     bool UpdateVotingKeyMeta(const CKeyID& keyId, const CVotingKeyMetadata& keyMeta);
     bool UpdateVotingKeyRegistration(const CKeyID& keyId, const uint256& txHash);
-    bool UpdateVotedMap(const CKeyID& keyId, const std::map<int64_t, uint256>& mapVoted);
-    bool UpdateVoteProofs(const CKeyID& keyId, const std::map<int64_t, uint256>& mapVoteProofs);
 
     bool WriteCScript(const uint160& hash, const CScript& redeemScript);
 


### PR DESCRIPTION
This PR bundles the following:
- Clean-up dead code related to vote proofs
- Rename vote proof by activation tx
- Fix activation transaction generation that generated 2 outputs
- Rework SmartRewards UI tab to show relevant Activation information