### PR TITLE
Add time-locked payment requests

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -180,6 +180,7 @@ QT_MOC_CPP = \
   qt/moc_smartproposaltab.cpp \
   qt/moc_splashscreen.cpp \
   qt/moc_specialtransactiondialog.cpp \
+  qt/moc_timelocksettingswidget.cpp \
   qt/moc_trafficgraphwidget.cpp \
   qt/moc_transactiondesc.cpp \
   qt/moc_transactiondescdialog.cpp \
@@ -269,6 +270,7 @@ BITCOIN_QT_H = \
   qt/smartproposaltab.h \
   qt/splashscreen.h \
   qt/specialtransactiondialog.h \
+  qt/timelocksettingswidget.h \
   qt/trafficgraphdata.h \
   qt/trafficgraphwidget.h \
   qt/transactiondesc.h \
@@ -405,6 +407,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/smartvotingmanager.cpp \
   qt/smartproposaltab.cpp \
   qt/specialtransactiondialog.cpp \
+  qt/timelocksettingswidget.cpp \
   qt/transactiondesc.cpp \
   qt/transactiondescdialog.cpp \
   qt/transactionfilterproxy.cpp \

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -42,9 +42,6 @@ public:
 
 public Q_SLOTS:
     void accept();
-    void timelockComboChanged(int);
-    void timeLockCustomBlocksChanged(int);
-    void timeLockCustomDateChanged(const QDateTime&);
 
 private:
     bool saveCurrentRow();
@@ -55,8 +52,6 @@ private:
     AddressTableModel *model;
 
     QString address;
-    std::vector<std::pair<QString, int>> timeLockItems;
-    int64_t nLockTime;
 };
 
 #endif // BITCOIN_QT_EDITADDRESSDIALOG_H

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -54,40 +54,9 @@
       </widget>
      </item>
     </layout>
-  </item>
+   </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QComboBox" name="timelockCombo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Create an address whose coins cannot be spent before a predefined locking period.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="timeLockCustomBlocks">
-       <property name="suffix">
-        <string> block height</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDateTimeEdit" name="timeLockCustomDate">
-       <property name="calendarPopup">
-        <bool>true</bool>
-       </property>
-       <property name="displayFormat">
-        <string>MMMM d yy hh:mm:ss</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="TimeLockSettingsWidget" name="timeLockSettings" native="true" />
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -170,34 +170,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="timelockCombo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Lock a transaction to be spent at future time.</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="timeLockCustomBlocks">
-            <property name="suffix">
-             <string> block height</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDateTimeEdit" name="timeLockCustomDate">
-            <property name="calendarPopup">
-             <bool>true</bool>
-            </property>
-            <property name="displayFormat">
-             <string>MMMM d yy hh:mm:ss</string>
-            </property>
-           </widget>
+           <widget class="TimeLockSettingsWidget" name="timeLockSettings" native="true" />
           </item>
           <item>
            <widget class="QCheckBox" name="checkUseInstantSend">

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -170,6 +170,36 @@
            </widget>
           </item>
           <item>
+           <widget class="QComboBox" name="timelockCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Lock a transaction to be spent at future time.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="timeLockCustomBlocks">
+            <property name="suffix">
+             <string> block height</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDateTimeEdit" name="timeLockCustomDate">
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+            <property name="displayFormat">
+             <string>MMMM d yy hh:mm:ss</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="checkUseInstantSend">
             <property name="text">
              <string>Request InstantPay</string>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -703,34 +703,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="timelockCombo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Lock a transaction to be spent at future time.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="timeLockCustomBlocks">
-       <property name="suffix">
-        <string> block height</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDateTimeEdit" name="timeLockCustomDate">
-       <property name="calendarPopup">
-        <bool>true</bool>
-       </property>
-       <property name="displayFormat">
-        <string>MMMM d yy hh:mm:ss</string>
-       </property>
-      </widget>
+      <widget class="TimeLockSettingsWidget" name="timeLockSettings" native="true" />
      </item>
      <item>
       <widget class="QCheckBox" name="checkUseInstantSend">

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -14,6 +14,7 @@
 #include "receiverequestdialog.h"
 #include "recentrequeststablemodel.h"
 #include "walletmodel.h"
+#include "validation.h"
 
 #include <QAction>
 #include <QCursor>
@@ -22,12 +23,16 @@
 #include <QScrollBar>
 #include <QTextDocument>
 
+#define ONE_MONTH                     (30.5 * 24 * 60 * 60)
+#define ONE_YEAR                      (365 * 24 * 60 * 60)
+
 ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *platformStyle, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ReceiveCoinsDialog),
     columnResizingFixer(0),
     model(0),
-    platformStyle(platformStyle)
+    platformStyle(platformStyle),
+    nLockTime(0)
 {
     ui->setupUi(this);
 
@@ -61,6 +66,36 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *platformStyle, QWidg
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
 
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+
+    // Timelock
+    const int nAvgBlockTime = Params().GetConsensus().nPowTargetSpacing;
+    timeLockItems.emplace_back("Set LockTime", 0);
+    timeLockItems.emplace_back("1 month", (int)(ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("2 months", (int)(2 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("3 months", (int)(3 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("6 months", (int)(6 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("1 year", (int)(ONE_YEAR / nAvgBlockTime));
+    timeLockItems.emplace_back("Custom (until block)", -1);
+    timeLockItems.emplace_back("Custom (until date)", -1);
+    for (const auto &i : timeLockItems) {
+        ui->timelockCombo->addItem(i.first);
+    }
+
+    // Make Timelock feature visible only if supermajority enforced BIP65
+    if(!IsSuperMajority(4, chainActive.Tip(), Params().GetConsensus().nMajorityEnforceBlockUpgrade,
+          Params().GetConsensus()))
+    {
+        ui->timelockCombo->setVisible(false);
+    }
+
+    ui->timeLockCustomBlocks->setVisible(false);
+    ui->timeLockCustomBlocks->setRange(1, 1000000);
+    ui->timeLockCustomDate->setVisible(false);
+    ui->timeLockCustomDate->setMinimumDateTime(QDateTime::currentDateTime());
+    connect(ui->timeLockCustomBlocks, SIGNAL(valueChanged(int)), this, SLOT(timeLockCustomBlocksChanged(int)));
+    connect(ui->timeLockCustomDate, SIGNAL(dateTimeChanged(const QDateTime&)), this,
+        SLOT(timeLockCustomDateChanged(const QDateTime&)));
+    connect(ui->timelockCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(timelockComboChanged(int)));
 }
 
 void ReceiveCoinsDialog::setModel(WalletModel *model)
@@ -155,7 +190,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
         }else{
           receive = AddressTableModel::Receive;
         }
-        address = model->getAddressTableModel()->addRow(receive, label, "");
+        address = model->getAddressTableModel()->addRow(receive, label, "", nLockTime);
     }
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());
@@ -277,4 +312,35 @@ void ReceiveCoinsDialog::copyMessage()
 void ReceiveCoinsDialog::copyAmount()
 {
     copyColumnToClipboard(RecentRequestsTableModel::Amount);
+}
+
+void ReceiveCoinsDialog::timelockComboChanged(int index)
+{
+    if (timeLockItems[index].first == "Custom (until block)") {
+        ui->timeLockCustomDate->setVisible(false);
+        ui->timeLockCustomBlocks->setVisible(true);
+        nLockTime = ui->timeLockCustomBlocks->value();
+    }
+    else if (timeLockItems[index].first == "Custom (until date)")
+    {
+        ui->timeLockCustomDate->setVisible(true);
+        ui->timeLockCustomBlocks->setVisible(false);
+        nLockTime = ui->timeLockCustomDate->dateTime().toMSecsSinceEpoch() / 1000;
+    }
+    else
+    {
+        ui->timeLockCustomDate->setVisible(false);
+        ui->timeLockCustomBlocks->setVisible(false);
+        nLockTime = timeLockItems[index].second > 0 ? chainActive.Height() + timeLockItems[index].second : 0;
+    }
+}
+
+void ReceiveCoinsDialog::timeLockCustomBlocksChanged(int i)
+{
+    nLockTime = i;
+}
+
+void ReceiveCoinsDialog::timeLockCustomDateChanged(const QDateTime &dt)
+{
+    nLockTime = dt.toMSecsSinceEpoch() / 1000;
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -59,8 +59,6 @@ private:
     WalletModel *model;
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
-    std::vector<std::pair<QString, int>> timeLockItems;
-    int64_t nLockTime;
 
     void copyColumnToClipboard(int column);
     virtual void resizeEvent(QResizeEvent *event);
@@ -76,9 +74,6 @@ private Q_SLOTS:
     void copyLabel();
     void copyMessage();
     void copyAmount();
-    void timelockComboChanged(int);
-    void timeLockCustomBlocksChanged(int);
-    void timeLockCustomDateChanged(const QDateTime&);
 };
 
 #endif // BITCOIN_QT_RECEIVECOINSDIALOG_H

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -59,6 +59,8 @@ private:
     WalletModel *model;
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
+    std::vector<std::pair<QString, int>> timeLockItems;
+    int64_t nLockTime;
 
     void copyColumnToClipboard(int column);
     virtual void resizeEvent(QResizeEvent *event);
@@ -74,6 +76,9 @@ private Q_SLOTS:
     void copyLabel();
     void copyMessage();
     void copyAmount();
+    void timelockComboChanged(int);
+    void timeLockCustomBlocksChanged(int);
+    void timeLockCustomDateChanged(const QDateTime&);
 };
 
 #endif // BITCOIN_QT_RECEIVECOINSDIALOG_H

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -64,8 +64,6 @@ private:
     bool fNewRecipientAllowed;
     bool fFeeMinimized;
     const PlatformStyle *platformStyle;
-    std::vector<std::pair<QString, int>> timeLockItems;
-    int64_t nLockTime;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
@@ -94,9 +92,6 @@ private Q_SLOTS:
     void coinControlClipboardPriority();
     void coinControlClipboardLowOutput();
     void coinControlClipboardChange();
-    void timelockComboChanged(int);
-    void timeLockCustomBlocksChanged(int);
-    void timeLockCustomDateChanged(const QDateTime&);
     void setMinimumFee();
     void updateFeeSectionControls();
     void updateMinFeeLabel();

--- a/src/qt/timelocksettingswidget.cpp
+++ b/src/qt/timelocksettingswidget.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 The SmartCash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <QHBoxLayout>
+
+#include "validation.h"
+#include "chainparams.h"
+
+#include "timelocksettingswidget.h"
+
+#define ONE_MONTH                     (30.5 * 24 * 60 * 60)
+#define ONE_YEAR                      (365 * 24 * 60 * 60)
+
+TimeLockSettingsWidget::TimeLockSettingsWidget(QWidget *parent) :
+    QWidget(parent),
+    nLockTime(0)
+{
+    const int nAvgBlockTime = Params().GetConsensus().nPowTargetSpacing;
+    timeLockItems.emplace_back("Set LockTime", 0);
+    timeLockItems.emplace_back("1 month", (int)(ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("2 months", (int)(2 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("3 months", (int)(3 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("6 months", (int)(6 * ONE_MONTH / nAvgBlockTime));
+    timeLockItems.emplace_back("1 year", (int)(ONE_YEAR / nAvgBlockTime));
+    timeLockItems.emplace_back("Custom (until block)", -1);
+    timeLockItems.emplace_back("Custom (until date)", -1);
+
+    timeLockCombo = new QComboBox();
+    for (const auto &i : timeLockItems) {
+        timeLockCombo->addItem(i.first);
+    }
+
+    QSizePolicy sizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    sizePolicy.setHorizontalStretch(0);
+    sizePolicy.setVerticalStretch(0);
+
+    timeLockCombo->setSizePolicy(sizePolicy);
+    timeLockCombo->setToolTip("Lock a transaction to be spent at future time.");
+
+    // Make Timelock feature visible only if supermajority enforced BIP65
+    if(!IsSuperMajority(4, chainActive.Tip(), Params().GetConsensus().nMajorityEnforceBlockUpgrade,
+          Params().GetConsensus()))
+    {
+        timeLockCombo->setVisible(false);
+    }
+
+    timeLockCustomBlocks = new QSpinBox();
+    timeLockCustomBlocks->setVisible(false);
+    timeLockCustomBlocks->setRange(1, 1000000);
+    timeLockCustomBlocks->setValue(chainActive.Height());
+
+    timeLockCustomDate = new QDateTimeEdit();
+    timeLockCustomDate->setVisible(false);
+    timeLockCustomDate->setMinimumDateTime(QDateTime::currentDateTime());
+    timeLockCustomDate->setCalendarPopup(true);
+    timeLockCustomDate->setDisplayFormat("MMMM d yy hh:mm:ss");
+
+    connect(timeLockCustomBlocks, SIGNAL(valueChanged(int)), this, SLOT(timeLockCustomBlocksChanged(int)));
+    connect(timeLockCustomDate, SIGNAL(dateTimeChanged(const QDateTime&)), this,
+        SLOT(timeLockCustomDateChanged(const QDateTime&)));
+    connect(timeLockCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(timeLockComboChanged(int)));
+
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->addWidget(timeLockCombo);
+    layout->addWidget(timeLockCustomBlocks);
+    layout->addWidget(timeLockCustomDate);
+}
+
+void TimeLockSettingsWidget::timeLockComboChanged(int index)
+{
+    if (timeLockItems[index].first == "Custom (until block)") {
+        timeLockCustomDate->setVisible(false);
+        timeLockCustomBlocks->setVisible(true);
+        nLockTime = timeLockCustomBlocks->value();
+    }
+    else if (timeLockItems[index].first == "Custom (until date)")
+    {
+        timeLockCustomDate->setVisible(true);
+        timeLockCustomBlocks->setVisible(false);
+        nLockTime = timeLockCustomDate->dateTime().toMSecsSinceEpoch() / 1000;
+    }
+    else
+    {
+        timeLockCustomDate->setVisible(false);
+        timeLockCustomBlocks->setVisible(false);
+        nLockTime = timeLockItems[index].second > 0 ? chainActive.Height() + timeLockItems[index].second : 0;
+    }
+}
+
+void TimeLockSettingsWidget::timeLockCustomBlocksChanged(int i)
+{
+    nLockTime = i;
+}
+
+void TimeLockSettingsWidget::timeLockCustomDateChanged(const QDateTime& dt)
+{
+    nLockTime = dt.toMSecsSinceEpoch() / 1000;
+}
+
+void TimeLockSettingsWidget::reset()
+{
+    timeLockCombo->setCurrentIndex(0);
+    timeLockCustomBlocks->setVisible(false);
+    timeLockCustomDate->setVisible(false);
+}

--- a/src/qt/timelocksettingswidget.h
+++ b/src/qt/timelocksettingswidget.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 The SmartCash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TIMELOCKSETTINGSWIDGET_H
+#define BITCOIN_QT_TIMELOCKSETTINGSWIDGET_H
+
+#include <vector>
+#include <utility>
+
+#include <QWidget>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QDateTimeEdit>
+
+class TimeLockSettingsWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TimeLockSettingsWidget(QWidget *parent = 0);
+
+    int64_t getLockTime() { return nLockTime; }
+    void reset();
+
+private:
+    QComboBox *timeLockCombo;
+    QSpinBox *timeLockCustomBlocks;
+    QDateTimeEdit *timeLockCustomDate;
+    std::vector<std::pair<QString, int>> timeLockItems;
+    int64_t nLockTime;
+
+private Q_SLOTS:
+    void timeLockComboChanged(int);
+    void timeLockCustomBlocksChanged(int);
+    void timeLockCustomDateChanged(const QDateTime&);
+};
+
+#endif // BITCOIN_QT_TIMELOCKSETTINGSWIDGET_H


### PR DESCRIPTION
This PR introduces the following:
- Show time-lock settings in the send tab to create time-locked payment requests
- Move all time-lock related UI stuff to a custom TimeLockSettings widget
- Show current block height when selecting custom block height for time locking