### PR TITLE
Show 1.3 bonus level on eligible addresses in SmartRewards tab

### DIFF
--- a/src/qt/forms/smartrewardentry.ui
+++ b/src/qt/forms/smartrewardentry.ui
@@ -114,6 +114,19 @@
           </widget>
          </item>
          <item>
+          <widget class="QLabel" name="lblBonus">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: rgb(60, 179, 113);</string>
+            </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLabel" name="lblEligible">
            <property name="text">
             <string>100 SMART</string>

--- a/src/qt/smartrewardentry.cpp
+++ b/src/qt/smartrewardentry.cpp
@@ -20,6 +20,7 @@ QSmartRewardEntry::QSmartRewardEntry(const QString& strLabel, const QString& str
 
     ui->lblLabel->setText(strLabel);
     ui->lblAddress->setText(strAddress);
+    ui->lblBonus->setVisible(false);
 
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
@@ -95,6 +96,28 @@ void QSmartRewardEntry::setActivated(bool fState)
 void QSmartRewardEntry::setIsSmartNode(bool fState)
 {
     fIsSmartNode = fState;
+}
+
+void QSmartRewardEntry::setBonusText(uint8_t bonusLevel)
+{
+    switch (bonusLevel) {
+        case CSmartRewardEntry::TwoMonthsBonus:
+            ui->lblBonus->setText("2 months bonus");
+            ui->lblBonus->setVisible(true);
+            break;
+        case CSmartRewardEntry::FourMonthsBonus:
+            ui->lblBonus->setText("4 months bonus");
+            ui->lblBonus->setVisible(true);
+            break;
+        case CSmartRewardEntry::SixMonthsBonus:
+            ui->lblBonus->setText("6 months bonus");
+            ui->lblBonus->setVisible(true);
+            break;
+        default:
+            ui->lblBonus->setText("");
+            ui->lblBonus->setVisible(false);
+            break;
+    }
 }
 
 QString QSmartRewardEntry::Address() const

--- a/src/qt/smartrewardentry.h
+++ b/src/qt/smartrewardentry.h
@@ -35,6 +35,7 @@ public:
     void setEligible(CAmount nEligible, CAmount nEstimated);
     void setIsSmartNode(bool fState);
     void setActivated(bool fState);
+    void setBonusText(uint8_t bonusLevel);
 
     QString Address() const;
     CAmount Balance() const { return nBalance; }

--- a/src/qt/smartrewardslist.cpp
+++ b/src/qt/smartrewardslist.cpp
@@ -47,11 +47,13 @@ struct QSmartRewardField
     uint256 disqualifyingTx;
     bool fIsSmartNode;
     bool fActivated;
+    uint8_t bonusLevel;
 
     QSmartRewardField() : label(QString()), address(QString()),
                           balance(0), eligible(0),reward(0),
                           disqualifyingTx(),
-                          fIsSmartNode(false), fActivated(false){}
+                          fIsSmartNode(false), fActivated(false),
+                          bonusLevel(CSmartRewardEntry::NoBonus) {}
 };
 
 struct SortSmartRewardWidgets
@@ -297,6 +299,7 @@ void SmartrewardsList::updateOverviewUI(const CSmartRewardRound &currentRound, c
                 rewardField.balanceAtStart = reward->balanceAtStart;
                 rewardField.disqualifyingTx = reward->disqualifyingTx;
                 rewardField.fActivated = reward->fActivated;
+                rewardField.bonusLevel = reward->bonusLevel;
 
                 if( !currentRound.Is_1_3() ){
                     rewardField.eligible = reward->balanceEligible && reward->disqualifyingTx.IsNull() ? reward->balanceEligible : 0;
@@ -360,6 +363,7 @@ void SmartrewardsList::updateOverviewUI(const CSmartRewardRound &currentRound, c
         if( currentRound.Is_1_3() ){
 
             entry->setMinBalance(SMART_REWARDS_MIN_BALANCE_1_3);
+            entry->setBonusText(field.bonusLevel);
 
             if( field.fIsSmartNode ){
                 entry->setInfoText("Address belongs to a SmartNode.", COLOR_NEGATIVE);

--- a/src/smartrewards/rewards.cpp
+++ b/src/smartrewards/rewards.cpp
@@ -287,17 +287,22 @@ void CSmartRewards::EvaluateRound(CSmartRewardRound &next)
 
                     // If we are at a "special round", add to the eligible balance with proper weight
                     CAmount toAdd = 0;
+                    CSmartRewardEntry::BonusLevel bonus = CSmartRewardEntry::NoBonus;
                     if (roundNumber == cache.GetCurrentRound()->number - 8) {
                         toAdd = addressResult->entry.balance;
+                        bonus = CSmartRewardEntry::TwoMonthsBonus;
                     } else if (roundNumber == cache.GetCurrentRound()->number - 16) {
                         toAdd = 2 * addressResult->entry.balance;
+                        bonus = CSmartRewardEntry::FourMonthsBonus;
                     } else if (roundNumber == cache.GetCurrentRound()->number - 26) {
                         toAdd = 2 * addressResult->entry.balance;
+                        bonus = CSmartRewardEntry::SixMonthsBonus;
                     }
 
                     if (toAdd > 0) {
                         auto &cacheEntry = cache.GetEntries()->at(*address);
                         cacheEntry->balanceEligible += toAdd;
+                        cacheEntry->bonusLevel = bonus;
                         next.eligibleSmart += toAdd;
                     }
 

--- a/src/smartrewards/rewardsdb.cpp
+++ b/src/smartrewards/rewardsdb.cpp
@@ -373,17 +373,19 @@ void CSmartRewardEntry::SetNull()
     fSmartnodePaymentTx = false;
     activationTx.SetNull();
     fActivated = false;
+    bonusLevel = NoBonus;
 }
 
 string CSmartRewardEntry::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CSmartRewardEntry(id=%s, balance=%d, balanceEligible=%d, isSmartNode=%b, activated=%b)\n",
+    s << strprintf("CSmartRewardEntry(id=%s, balance=%d, balanceEligible=%d, isSmartNode=%b, activated=%b, bonus=%d)\n",
         GetAddress(),
         balance,
         balanceEligible,
         fSmartnodePaymentTx,
-        fActivated);
+        fActivated,
+        bonusLevel);
     return s.str();
 }
 

--- a/src/smartrewards/rewardsdb.h
+++ b/src/smartrewards/rewardsdb.h
@@ -207,7 +207,15 @@ public:
         READWRITE(fActivated);
         READWRITE(smartnodePaymentTx);
         READWRITE(fSmartnodePaymentTx);
+        READWRITE(bonusLevel);
     }
+
+    enum BonusLevel {
+      NoBonus = 0,
+      TwoMonthsBonus,
+      FourMonthsBonus,
+      SixMonthsBonus
+    };
 
     CSmartAddress id;
     CAmount balance;
@@ -219,17 +227,20 @@ public:
     bool fActivated;
     uint256 smartnodePaymentTx;
     bool fSmartnodePaymentTx;
+    uint8_t bonusLevel;
 
     CSmartRewardEntry() : id(CSmartAddress()),
                           balance(0), balanceAtStart(0), balanceEligible(0),
                           disqualifyingTx(uint256()), fDisqualifyingTx(false),
                           activationTx(uint256()), fActivated(false),
-                          smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false) {}
+                          smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false),
+                          bonusLevel(NoBonus) {}
     CSmartRewardEntry(const CSmartAddress &address) : id(address),
                           balance(0), balanceAtStart(0), balanceEligible(0),
                           disqualifyingTx(uint256()), fDisqualifyingTx(false),
                           activationTx(uint256()), fActivated(false),
-                          smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false) {}
+                          smartnodePaymentTx(uint256()), fSmartnodePaymentTx(false),
+                          bonusLevel(NoBonus) {}
 
     friend bool operator==(const CSmartRewardEntry& a, const CSmartRewardEntry& b)
     {


### PR DESCRIPTION
This PR adds UI element to show if an address is eligible to the 2/4/6 months bonus in the SmartRewards tab